### PR TITLE
(SIMP-8806) Disable Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,18 @@ before_install:
 
 jobs:
   include:
-    - stage: check
-      rvm: 2.4.5
-      script:
-        - bundle exec rake fingerprint
-        - bundle exec rake pkg:compare_latest_tag
-        - bundle exec rake pkg:create_tag_changelog
+    ###  Testing on Travis CI is indefinitely disabled
+    ###
+    ###  See:
+    ###    * https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+    ###    * https://simp-project.atlassian.net/browse/SIMP-8703
+    ###
+    ###    - stage: check
+    ###      rvm: 2.4.5
+    ###      script:
+    ###        - bundle exec rake fingerprint
+    ###        - bundle exec rake pkg:compare_latest_tag
+    ###        - bundle exec rake pkg:create_tag_changelog
 
     - stage: deploy
       rvm: 2.4.5


### PR DESCRIPTION
This patch disables tests in the Travis CI pipeline.

[SIMP-8806] #close

[SIMP-8806]: https://simp-project.atlassian.net/browse/SIMP-8806